### PR TITLE
update y18n vulnerable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,7 +1322,7 @@
             "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
+            "y18n": "^4.0.1",
             "yargs-parser": "^18.1.2"
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,7 @@ cacache@^12.0.2, cacache@^12.0.3:
     rimraf "^2.6.3"
     ssri "^6.0.1"
     unique-filename "^1.1.1"
-    y18n "^4.0.0"
+    y18n "^4.0.1"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -5037,9 +5037,9 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
   dependencies:
     figgy-pudding "^3.5.1"
 


### PR DESCRIPTION
I updated the versions for y18n in this PR. I have a feeling these 2 files are autogenerated as homebrew or npm or some other service is used to include the files.

There are several other vulnerabilities being listed for these files by dependabot.
https://github.com/nih-cfde/dashboard/security/dependabot