### PR TITLE
Remove the data preview table

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,6 @@
 	    <p>More at: <a href="https://www.nih-cfde.org/" target="_blank">https://www.nih-cfde.org/ <i class="fas fa-external-link-alt"></i></a></p>
           </div>
 	</div>
-	<div class="top_content_section_right">
-          <table id="data_preview_table" class="data_preview">
-          </table>
-	</div><!-- end Top Content-Section-Right-->
       </div><!-- End Top Content-->
 
       <div class="content">

--- a/js/index.js
+++ b/js/index.js
@@ -154,7 +154,6 @@ $(document).ready(function() {
     register_dropdowns(catalog_id, 'sbc1');
     window.onload = function() {
       update_chart(catalog_id, 'sbc1');
-      add_summary_data(catalog_id);
       window.addEventListener('resize', function() { window_resized(catalog_id, 'sbc1'); });
     };
 });


### PR DESCRIPTION
This PR removes the HTML element for the data preview table and no longer makes the request to fetch the data. This was asked to be changed prior to the data release for the beginning of july. These changes were applied to dev and production already, just adding them to the repo to have consistency.